### PR TITLE
Add sailing learning CLI app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# number1
-my test one
+# Sailing Learning Tool
+
+This repository contains a simple command-line application to help users learn sailing and yacht navigation basics. Features include:
+
+- Lookup common sailing terms
+- Short quizzes to test your knowledge
+- A basic navigation exercise
+- Progress tracking stored in `~/.sailing_progress.json`
+
+Run the application:
+
+```bash
+python -m sailing_app.main
+```
+

--- a/sailing_app/__init__.py
+++ b/sailing_app/__init__.py
@@ -1,0 +1,4 @@
+"""Simple Sailing Learning Tool."""
+
+__all__ = ["terms", "main", "progress"]
+

--- a/sailing_app/main.py
+++ b/sailing_app/main.py
@@ -1,0 +1,67 @@
+from random import choice
+from . import terms
+from .progress import load_progress, save_progress
+
+
+def show_menu():
+    print("Sailing Learning Tool")
+    print("1. Look up a term")
+    print("2. Take a quiz")
+    print("3. Navigation exercise")
+    print("4. Exit")
+
+
+def lookup_term(progress):
+    term = input("Enter a sailing term: ").strip().lower()
+    definition = terms.TERMS.get(term)
+    if definition:
+        print(f"{term}: {definition}")
+        progress.setdefault("terms_viewed", {}).setdefault(term, 0)
+        progress["terms_viewed"][term] += 1
+        save_progress(progress)
+    else:
+        print("Term not found.")
+
+
+def quiz(progress):
+    term = choice(list(terms.TERMS.keys()))
+    answer = input(f"What does '{term}' mean? ").strip().lower()
+    if answer in terms.TERMS[term].lower():
+        print("Correct!")
+        progress.setdefault("quizzes_passed", 0)
+        progress["quizzes_passed"] += 1
+    else:
+        print(f"Incorrect. {term}: {terms.TERMS[term]}")
+    save_progress(progress)
+
+
+def navigation_exercise():
+    print("You are approaching a buoy marking a channel. Should you leave it to port or starboard?")
+    choice_in = input("Enter 'port' or 'starboard': ").strip().lower()
+    if choice_in == "starboard":
+        print("Correct! Green buoys are left to starboard when returning from sea.")
+    else:
+        print("Incorrect. The correct answer is 'starboard'.")
+
+
+def main():
+    progress = load_progress()
+    while True:
+        show_menu()
+        option = input("Choose an option: ").strip()
+        if option == "1":
+            lookup_term(progress)
+        elif option == "2":
+            quiz(progress)
+        elif option == "3":
+            navigation_exercise()
+        elif option == "4":
+            print("Goodbye!")
+            break
+        else:
+            print("Invalid choice")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/sailing_app/progress.py
+++ b/sailing_app/progress.py
@@ -1,0 +1,17 @@
+import json
+from pathlib import Path
+
+PROGRESS_FILE = Path.home() / '.sailing_progress.json'
+
+
+def load_progress():
+    if PROGRESS_FILE.exists():
+        with open(PROGRESS_FILE, 'r') as f:
+            return json.load(f)
+    return {}
+
+
+def save_progress(data):
+    with open(PROGRESS_FILE, 'w') as f:
+        json.dump(data, f)
+

--- a/sailing_app/terms.py
+++ b/sailing_app/terms.py
@@ -1,0 +1,10 @@
+TERMS = {
+    "bow": "The front part of a boat.",
+    "stern": "The rear part of a boat.",
+    "port": "The left-hand side of the boat when facing the bow.",
+    "starboard": "The right-hand side of the boat when facing the bow.",
+    "tacking": "Turning the bow of the boat through the wind to change direction.",
+    "gybe": "Turning the stern of the boat through the wind to change direction.",
+    "knot": "A unit of speed equal to one nautical mile per hour.",
+}
+


### PR DESCRIPTION
## Summary
- add simple command line tool for sailing and yacht navigation learning
- track user progress in user's home directory
- document usage in README
- remove temporary pycache files

## Testing
- `python -m sailing_app.main <<'EOF'
4
EOF`
- `python -m sailing_app.main <<'EOF'
1
bow
4
EOF`
